### PR TITLE
Quickly correct the six-j bug.

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -12,3 +12,5 @@ build/
 .vscode/
 .cache/
 CMakeUserPresets.json
+imsrg++.cc
+imsrg++

--- a/src/ModelSpace.cc
+++ b/src/ModelSpace.cc
@@ -1690,18 +1690,22 @@ void ModelSpace::PreCalculateSixJ()
   std::cout << "Precalculating SixJ's" << std::endl;
   double t_start = omp_get_wtime();
   std::vector<uint64_t> KEYS;
-  for (int j2a = 1; j2a <= 3 * (2 * Emax + 1); j2a += 2)
+  int upperLimit_j2a = (2 * Emax + 1);
+  int upperLimit_j2b =  3 * (2 * Emax + 1);
+  int upperLimit_j2c = (2 * Emax + 1);
+  int upperLimit_j2d =  3 * (2 * Emax + 1);
+
+  for (int j2a = 1; j2a <= upperLimit_j2a; j2a += 2)
   {
-    //   for (int j2b=1; j2b<=(2*Emax+1); j2b+=2)
-    for (int j2b = 1; j2b <= 3 * (2 * Emax + 1); j2b += 2)
+    for (int j2b = 1; j2b <= upperLimit_j2b; j2b += 2)
     {
-      for (int j2c = 1; j2c <= (2 * Emax + 1); j2c += 2)
+      for (int j2c = 1; j2c <= upperLimit_j2c; j2c += 2)
       {
         // four half-integer j's,  two integer J's
-        for (int j2d = 1; j2d <= (2 * Emax + 1); j2d += 2)
+        for (int j2d = 1; j2d <= upperLimit_j2d; j2d += 2)
         {
-          //if (j2b > std::max(j2d, 2 * Emax + 1))
-          //  continue;
+          if (j2b > std::max(j2d, 2 * Emax + 1))
+            continue;
           // J1 couples a,b, and c,d;  J2 couples a,d and b,c
           // We extend the hash table to include symbols outside the coupling range for computational gain.
           // We may want to revert this change at some point.
@@ -1709,14 +1713,7 @@ void ModelSpace::PreCalculateSixJ()
           {
             for (int J2 = 0; J2 <= 2 * (Emax * 2 + 1); J2 += 2)
             {
-              uint64_t key = SixJHash(0.5 * j2b, 0.5 * j2d, 0.5 * J1, 0.5 * j2a, 0.5 * j2c, 0.5 * J2);
-              if (SixJList.count(key) == 0)
-              {
-                KEYS.push_back(key);
-                SixJList[key] = 0.; // Make sure eveything's in there to avoid a rehash in the parallel loop
-              }
-              
-              key = SixJHash(0.5 * j2c, 0.5 * j2d, 0.5 * J1, 0.5 * j2a, 0.5 * j2b, 0.5 * J2);
+              uint64_t key = SixJHash(0.5 * j2a, 0.5 * j2b, 0.5 * J1, 0.5 * j2c, 0.5 * j2d, 0.5 * J2);
               if (SixJList.count(key) == 0)
               {
                 KEYS.push_back(key);

--- a/src/ReferenceImplementations.cc
+++ b/src/ReferenceImplementations.cc
@@ -4703,7 +4703,7 @@ namespace ReferenceImplementations
 
                                        sixj *= AngMom::SixJ(twoj4 / 2.,  twoj5 / 2.,   Lambda,
                                                             twoj2 / 2.,  twoj1 / 2.,   J3);
-                                if (std::abs(sixj) < 1e-7)
+                                if (std::abs(sixj) < 1e-12)
                                   continue;
                                 int phasefactor = Z.modelspace->phase(( o3.j2  + o6.j2 + oc.j2 + twoj3) / 2 + J1p + J2p + Jab + J3 + Lambda);
                                 double hatfactor =  (twoj3 + 1) * (2 * J3 + 1) * sqrt( (twoj1 + 1) * ( twoj2 + 1) * ( twoj4 + 1) * (twoj5 + 1) );
@@ -4749,7 +4749,7 @@ namespace ReferenceImplementations
                                         sixj *= AngMom::SixJ(o6.j2 / 2.,  twoj6 / 2.,   J3,
                                                              o3.j2 / 2.,  twoj2 / 2.,   J2p);
 
-                                  if (std::abs(sixj) < 1e-7)
+                                  if (std::abs(sixj) < 1e-12)
                                     continue;
                                   int phasefactor = Z.modelspace->phase(( o3.j2  + twoj4 + oc.j2 + twoj2) / 2 );
                                   double hatfactor =  (twoj5 + 1) * (twoj6 + 1) * (2 * J3 + 1) * sqrt( (twoj1 + 1) * ( twoj2 + 1) * ( twoj3 + 1) * (twoj4 + 1) );

--- a/src/TensorCommutators.cc
+++ b/src/TensorCommutators.cc
@@ -1474,7 +1474,7 @@ namespace Commutator
                           if (std::abs(j0 - j1) > Lambda * 2 or (j0 + j1) < Lambda * 2)
                             continue;
                           //double sixj1 = AngMom::SixJ(oj.j2 / 2., oi.j2 / 2., Lambda, j0 / 2., j1 / 2., J1);
-                          double sixj1 = Z.modelspace->GetSixJ(oj.j2 / 2., oi.j2 / 2., Lambda, j0 / 2., j1 / 2., J1);
+                          double sixj1 = AngMom::SixJ(oj.j2 / 2., oi.j2 / 2., Lambda, j0 / 2., j1 / 2., J1);
 
                           if (std::abs(sixj1) < 1.e-6)
                             continue;
@@ -1500,7 +1500,7 @@ namespace Commutator
                             continue;
 
                           //double sixj1 = AngMom::SixJ(oj.j2 / 2., oi.j2 / 2., Lambda, j0 / 2., j1 / 2., J1);
-                          double sixj1 = Z.modelspace->GetSixJ(oj.j2 / 2., oi.j2 / 2., Lambda, j0 / 2., j1 / 2., J1);
+                          double sixj1 = AngMom::SixJ(oj.j2 / 2., oi.j2 / 2., Lambda, j0 / 2., j1 / 2., J1);
                           if (std::abs(sixj1) < 1.e-6)
                             continue;
 

--- a/src/TensorCommutators.cc
+++ b/src/TensorCommutators.cc
@@ -1548,6 +1548,8 @@ namespace Commutator
     // Permutations of indices which are needed to produce antisymmetrized matrix elements  P(ij/k) |ijk> = |ijk> - |kji> - |ikj>
     const std::array<ThreeBodyStorage::Permutation, 3> index_perms = {ThreeBodyStorage::ABC, ThreeBodyStorage::CBA, ThreeBodyStorage::ACB};
 
+    double tstart = omp_get_wtime();
+
     std::vector<std::array<size_t, 3>> bra_ket_channels;
     for (auto &it : Z.ThreeBody.Get_ch_start())
     {
@@ -1721,6 +1723,7 @@ namespace Commutator
       } // for iket
     } // for ch3
 
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm233st
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1746,6 +1749,8 @@ namespace Commutator
     int Lambda = Z.GetJRank();
     Z.modelspace->PreCalculateSixJ();
     size_t norb = Z.modelspace->GetNumberOrbits();
+
+    double tstart = omp_get_wtime();
 
   #pragma omp parallel for schedule(dynamic,1)
     for (size_t i = 0; i < norb; i++)
@@ -1852,6 +1857,8 @@ namespace Commutator
         Z1(i, j) += zij;
       } // j
     } // i
+  
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm231st
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1887,7 +1894,7 @@ namespace Commutator
     int Lambda = Z.GetJRank();
     Z.modelspace->PreCalculateSixJ();
     int nch = Z.modelspace->GetNumberTwoBodyChannels();
-
+    double tstart = omp_get_wtime();
     std::vector<std::array<size_t, 2>> channels;
     for (auto &iter : Z.TwoBody.MatEl)
       channels.push_back(iter.first);
@@ -2196,7 +2203,7 @@ namespace Commutator
         } // for iket
       } // for ibra
     } // for ch
-
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm232st
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2221,7 +2228,7 @@ namespace Commutator
     auto &Z3 = Z.ThreeBody;
     int Lambda = Z.GetJRank();
     Z.modelspace->PreCalculateSixJ();
-
+    double tstart = omp_get_wtime();
     std::vector<std::array<size_t, 3>> bra_ket_channels;
     for (auto &it : Z.ThreeBody.Get_ch_start())
     {
@@ -2471,7 +2478,7 @@ namespace Commutator
 
       } // for iket
     } // for ich  -> {ch_bra,ch_ket,ibra}
-
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm133st
 
 
@@ -2493,7 +2500,7 @@ namespace Commutator
     auto &Z2 = Z.TwoBody;
     int Lambda = Z.GetJRank();
     Z.modelspace->PreCalculateSixJ();
-
+    double tstart = omp_get_wtime();
     std::vector<size_t> ch_bra_list, ch_ket_list;
 
     for (auto &iter : Z.TwoBody.MatEl)
@@ -2578,6 +2585,8 @@ namespace Commutator
         } // iket
       } // ibra
     } // ch2
+  
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm132st
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2595,7 +2604,7 @@ namespace Commutator
     auto &Z2 = Z.TwoBody;
     int Lambda = Z.GetJRank();
     Z.modelspace->PreCalculateSixJ();
-
+    double tstart = omp_get_wtime();
     std::vector<int> bra_channels;
     std::vector<int> ket_channels;
     for (auto &itmat : Z.TwoBody.MatEl)
@@ -2691,7 +2700,7 @@ namespace Commutator
         } // iket
       } // ibra
     } // ch2
-
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm332_ppph_hhhpst
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2716,7 +2725,7 @@ namespace Commutator
     auto &Z2 = Z.TwoBody;
     int Lambda = Z.GetJRank();
     Z.modelspace->PreCalculateSixJ();
-
+    double tstart = omp_get_wtime();
     std::map<int, double> e_fermi = Z.modelspace->GetEFermi();
 
     std::vector<int> bra_channels;
@@ -2947,6 +2956,8 @@ namespace Commutator
         } // for iket
       } // for ibra
     } // for ch
+ 
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2975,7 +2986,7 @@ namespace Commutator
 
     // Permutations of indices which are needed to produce antisymmetrized matrix elements  P(ij/k) |ijk> = |ijk> - |kji> - |ikj>
     const std::array<ThreeBodyStorage::Permutation, 3> index_perms = {ThreeBodyStorage::ABC, ThreeBodyStorage::CBA, ThreeBodyStorage::ACB};
-
+    double tstart = omp_get_wtime();
     std::vector<std::array<size_t, 3>> bra_ket_channels;
     for (auto &it : Z.ThreeBody.Get_ch_start())
     {
@@ -3181,6 +3192,7 @@ namespace Commutator
       } // for iket
     } // for ch3 and ibra
 
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm233_pp_hhst
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3212,7 +3224,7 @@ namespace Commutator
 
     // Permutations of indices which are needed to produce antisymmetrized matrix elements  P(ij/k) |ijk> = |ijk> - |kji> - |ikj>
     const std::array<ThreeBodyStorage::Permutation, 3> index_perms = {ThreeBodyStorage::ABC, ThreeBodyStorage::CBA, ThreeBodyStorage::ACB};
-
+    double tstart = omp_get_wtime();
     std::vector<std::array<size_t, 3>> bra_ket_channels;
     for (auto &it : Z.ThreeBody.Get_ch_start())
     {
@@ -3419,7 +3431,8 @@ namespace Commutator
       } // for iket
         //    }//ibra
     } // ch
-    std::cout << "Ref " << __func__ << " Done" << std::endl;
+  
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm233_phst
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3445,7 +3458,7 @@ namespace Commutator
       }
     }
     size_t n_bra_ket_ch = bra_ket_channels.size();
-
+    double tstart = omp_get_wtime();
 #pragma omp parallel for schedule(dynamic, 1)
     for (size_t ibra_ket = 0; ibra_ket < n_bra_ket_ch; ibra_ket++)
     {
@@ -3506,7 +3519,7 @@ namespace Commutator
       } // iket : lmn
       //    }//ibra : ijk
     } // chbra, chket
-
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;
   } // comm333_ppp_hhhst
 
   void comm333_pph_hhpst(const Operator &X, const Operator &Y, Operator &Z)
@@ -3516,7 +3529,7 @@ namespace Commutator
     auto &Y3 = Y.ThreeBody;
     auto &Z3 = Z.ThreeBody;
     std::map<int, double> e_fermi = Z.modelspace->GetEFermi();
-
+    double tstart = omp_get_wtime();
     Z.modelspace->PreCalculateSixJ();
     int parityY = Y.GetParity();
     int parityZ = parityY;
@@ -3765,6 +3778,9 @@ namespace Commutator
         Z3.AddToME_pn_ch(ch3bra, ch3ket, ibra, iket, zijklmn);
       } // iket : lmn
     } // chbra, chket //ibra : ijk
+  
+    X.profiler.timer[__func__] += omp_get_wtime() - tstart;  
+  
   } // comm333_pph_hhpst
 
 }// namespace Commutator

--- a/src/UnitTest.cc
+++ b/src/UnitTest.cc
@@ -7414,6 +7414,10 @@ bool UnitTest::Mscheme_Test_comm333_pph_hhpst(const Operator &X, const Operator 
 
                           // if (not(m_i == 1 and m_j == -1 and m_k == 1 and m_l == 1 and m_m == -1 and m_n == 1))
                           //   continue;
+
+                          if ( (m_i + m_j + m_k < 0 and m_l + m_m + m_n < 0))
+                            continue;
+
                           double z_ijklmn = 0;
 
                           size_t norb = X.modelspace->GetNumberOrbits();


### PR DESCRIPTION
Roll back the function 'ModelSpace::PreCalculateSixJ()'.
Set all the IMSRG3 tensor commutators to evaluate the six-j on the fly temporarily. 