### PR TITLE
Fix implied Hermiticity of Phi' and Tilde Phi' structure functions

### DIFF
--- a/src/DarkMatterNREFT.cc
+++ b/src/DarkMatterNREFT.cc
@@ -783,7 +783,8 @@ namespace DM_NREFT
     else if (IsoSV == "p") isofactor[1] = 0; // proton only,  neutrons don't contribute.
     else if (IsoSV == "n") isofactor[0] = 0; // neutron only, protons don't contribute.
     Operator Phip_op(modelspace, J, Tz, parity, 2);
-    Phip_op.SetAntiHermitian();
+    std::cout << "Warning: Phi' is neither Hermitian nor anti-Hermitian!" << std::endl;
+    std::cout << "Warning: Check that you are using Tilde Phi ' (Phitp) for correct behavior." << std::endl;
     int norb = modelspace.GetNumberOrbits();
     for (int a=0; a<norb; a++)
     {
@@ -826,6 +827,7 @@ namespace DM_NREFT
   Operator Phitp( ModelSpace& modelspace, std::string IsoSV, int J, double q )
   {
     Operator Phitp_op = Phip(modelspace,IsoSV,J,q) + 0.5 * Ms(modelspace, IsoSV, J, J, q);
+    Phitp_op.SetHermitian();
     return Phitp_op;
   }
 


### PR DESCRIPTION
Fix incorrect anti-Hermiticity of Phi' structure function.

Phi' (`Phip`) as defined in Serot, NPA 308 (1978) does not have simple Hermiticity (easy to see numerically).

Tilde Phi' (`Phitp`) = Phi' + 0.5 Sigma as defined in Fitzpatrick et al., JCAP 2013 (2013) is Hermitian.

No changes are made to the numerical parts of the code, only to the flags that indicate the symmetry properties of the operator. I don't know if this actually matters.

Benchmarked against Berkeley Python code: https://github.com/Berkeley-Electroweak-Physics/Mu2e/blob/main/python/mu2e.py